### PR TITLE
Update cmake to 3.14.0-rc3

### DIFF
--- a/tools/Dockerfile.tmpl
+++ b/tools/Dockerfile.tmpl
@@ -49,7 +49,7 @@ RUN Install-Ruby -Version $env:RUBY_VERSION -InstallationPath C:\tools\ruby;
 # Install CMake
 #--------------------------------------------------------------------
 
-ENV CMAKE_VERSION 3.14.0-rc2
+ENV CMAKE_VERSION 3.14.0-rc3
 
 RUN Install-CMake -Version $env:CMAKE_VERSION -InstallationPath C:\tools\cmake;
 


### PR DESCRIPTION
3.14.0-rc2 (and possibly rc1) had an issue with removing directories in CMAKE_SYSTEM_INCLUDE_PATH from the command line regardless of whether they were implicitly added by the compiler. This should be fixed in rc3.