### PR TITLE
Shorten basedir to fit more in 260 character path names

### DIFF
--- a/buildbot/Dockerfile
+++ b/buildbot/Dockerfile
@@ -34,11 +34,11 @@ RUN Write-Host 'Installing buildbot ...'; `
 # Copy files
 #--------------------------------------------------------------------
 
-COPY WebKit-BuildWorker C:/WebKit-BuildWorker
+COPY WebKit-BuildWorker C:/BW
 
 #--------------------------------------------------------------------
 # Entrypoint
 #--------------------------------------------------------------------
 
-WORKDIR C:\\WebKit-BuildWorker
+WORKDIR C:\\BW
 CMD powershell .\\Run-BuildbotWorker.ps1

--- a/buildbot/WebKit-BuildWorker/buildbot.tac.tmpl
+++ b/buildbot/WebKit-BuildWorker/buildbot.tac.tmpl
@@ -3,7 +3,7 @@ import os
 from buildslave.bot import BuildSlave
 from twisted.application import service
 
-basedir = 'C:\\WebKit-BuildWorker'
+basedir = 'C:\\BW'
 rotateLength = 10000000
 maxRotatedFiles = 10
 


### PR DESCRIPTION
This may be just enough to get the couple long pathnames in the repo down to under 260 and allow the removal code to work.