### PR TITLE
Add workaround to preload svn contents

### DIFF
--- a/buildbot/WebKit-BuildWorker/Scripts/Workaround-SvnPreload.ps1
+++ b/buildbot/WebKit-BuildWorker/Scripts/Workaround-SvnPreload.ps1
@@ -1,0 +1,30 @@
+Write-Host "If requested, preload webkit svn"
+
+if (Test-Path 'env:SVN_PRELOAD') {
+    $count = 0
+
+    Write-Host "Preloading webkit svn to $env:SVN_PRELOAD"
+    svn checkout --non-interactive --no-auth-cache `
+        https://svn.webkit.org/repository/webkit/trunk `
+        $env:SVN_PRELOAD/build
+    while ($LASTEXITCODE -and $count -lt 10) {
+        $count = $count + 1
+        Write-Host "Failed checkout, $count"
+        pushd $env:SVN_PRELOAD/build
+        svn cleanup
+        popd
+        svn checkout --non-interactive --no-auth-cache `
+             https://svn.webkit.org/repository/webkit/trunk `
+             $env:SVN_PRELOAD/build
+    }
+
+    if ($LASTEXITCODE) {
+        Write-Host "Failed to update in 10 tries"
+    }
+    else {
+        "https://svn.webkit.org/repository/webkit/trunk" | `
+            out-file -encoding ASCII `
+            "$env:SVN_PRELOAD/.buildbot-sourcedata-YnVpbGQ="
+    }
+}
+


### PR DESCRIPTION
(Hopefully) Short-term workaround for starting buildbot images in the AWS bot environment as we fairly regularly fail a full pull of the webkit svn repository due to network issue. This shouldn't be necessary for ews, as that's pulling git which doesn't seem to have the same issue.

If we get a location to put it in, try to pull the repository into there before starting the buildslave. Retry a number of times with svn cleanup between in case of failures. In the couple of start attempts I've made with an image built with this script included, it's always successfully finished the checkout on the second attempt, but I don't think that's a guarantee.
