### PR TITLE
Add servercore "aws-safe" image base

### DIFF
--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory)]
-  [ValidateSet('1803','1809','1903','1909','2004','windows-1809','windows-1903','windows-1909','windows-2004')]
+  [ValidateSet('1803','1809','1903','1909','2004','windows-1809','windows-1903','windows-1909','windows-2004','aws')]
   [string]$tag
 )
 

--- a/Publish-All.ps1
+++ b/Publish-All.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory)]
-  [ValidateSet('1803','1809','1903','1909','2004','windows-1809','windows-1903','windows-1909','windows-2004')]
+  [ValidateSet('1803','1809','1903','1909','2004','windows-1809','windows-1903','windows-1909','windows-2004','aws')]
   [string]$tag
 )
 

--- a/base/Dockerfile.aws
+++ b/base/Dockerfile.aws
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019@sha256:578d07650a3dfe8db5b988f26aa0c23180a248bcb7f5e1ab1d7ba7713b73ad43


### PR DESCRIPTION
This was the base servercore image for which the wincairo aws environment seemed to be okay for running the various executables that started failing later.