### PR TITLE
Revert changes to the Dockerfile.aws pinning

### DIFF
--- a/base/Dockerfile.aws
+++ b/base/Dockerfile.aws
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019@sha256:8a3e3cac97f04de4683e0f54f9a2be97c1fd4f92f76ac30449f34d18eafb4f28
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019@sha256:578d07650a3dfe8db5b988f26aa0c23180a248bcb7f5e1ab1d7ba7713b73ad43


### PR DESCRIPTION
Renovatebot managed to update this despite this not being a `fileMatch`.