### PR TITLE
Remove 1803 support

### DIFF
--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory)]
-  [ValidateSet('1803','1809','1903','1909','2004','20H2','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws')]
+  [ValidateSet('1809','1903','1909','2004','20H2','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws')]
   [string]$tag
 )
 

--- a/Publish-All.ps1
+++ b/Publish-All.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory)]
-  [ValidateSet('1803','1809','1903','1909','2004','20H2','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws')]
+  [ValidateSet('1809','1903','1909','2004','20H2','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws')]
   [string]$tag
 )
 

--- a/base/Dockerfile.1803
+++ b/base/Dockerfile.1803
@@ -1,1 +1,0 @@
-FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-1803@sha256:0ad6735e4c776d881ec2c48c1a61ad57f5ef3dfe3e0410c71e98c2e12942f907

--- a/base/manifest.tmpl
+++ b/base/manifest.tmpl
@@ -7,12 +7,6 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/base:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1803
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1803
-  -
     image: webkitdev/base:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
     platform:
       architecture: amd64

--- a/buildbot/manifest.tmpl
+++ b/buildbot/manifest.tmpl
@@ -7,12 +7,6 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/buildbot:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1803
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1803
-  -
     image: webkitdev/buildbot:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
     platform:
       architecture: amd64

--- a/ews-legacy/manifest.tmpl
+++ b/ews-legacy/manifest.tmpl
@@ -7,12 +7,6 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/ews-legacy:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1803
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1803
-  -
     image: webkitdev/ews-legacy:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
     platform:
       architecture: amd64

--- a/ews/manifest.tmpl
+++ b/ews/manifest.tmpl
@@ -7,12 +7,6 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/ews:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1803
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1803
-  -
     image: webkitdev/ews:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
     platform:
       architecture: amd64

--- a/msbuild-2017/manifest.tmpl
+++ b/msbuild-2017/manifest.tmpl
@@ -7,12 +7,6 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/msbuild-2017:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1803
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1803
-  -
     image: webkitdev/msbuild-2017:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
     platform:
       architecture: amd64

--- a/msbuild/manifest.tmpl
+++ b/msbuild/manifest.tmpl
@@ -7,12 +7,6 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/msbuild:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1803
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1803
-  -
     image: webkitdev/msbuild:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
     platform:
       architecture: amd64

--- a/scm/manifest.tmpl
+++ b/scm/manifest.tmpl
@@ -7,12 +7,6 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/scm:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1803
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1803
-  -
     image: webkitdev/scm:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
     platform:
       architecture: amd64

--- a/scripts/manifest.tmpl
+++ b/scripts/manifest.tmpl
@@ -7,12 +7,6 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/scripts:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1803
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1803
-  -
     image: webkitdev/scripts:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
     platform:
       architecture: amd64

--- a/tools/manifest.tmpl
+++ b/tools/manifest.tmpl
@@ -7,12 +7,6 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/tools:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1803
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1803
-  -
     image: webkitdev/tools:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
     platform:
       architecture: amd64


### PR DESCRIPTION
Microsoft ended support on November 12, 2019 for 1803. None of the base images are receiving updates so remove them.