### PR TITLE
Add Sony AWS safe windows-1809 based image

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -22,6 +22,8 @@ local tags = [
   'windows-1909',
   'windows-2004',
   'windows-20H2',
+  'aws',
+  'windows-aws'
 ];
 
 local pipeline_name(tag) =

--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory)]
-  [ValidateSet('1809','1903','1909','2004','20H2','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws')]
+  [ValidateSet('1809','1903','1909','2004','20H2','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws', 'windows-aws')]
   [string]$tag
 )
 

--- a/Publish-All.ps1
+++ b/Publish-All.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory)]
-  [ValidateSet('1809','1903','1909','2004','20H2','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws')]
+  [ValidateSet('1809','1903','1909','2004','20H2','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws', 'windows-aws')]
   [string]$tag
 )
 

--- a/base/Dockerfile.windows-aws
+++ b/base/Dockerfile.windows-aws
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/windows:1809@sha256:bf5f60839adcb5cfd775243bb86069deb88083217c656c456d90fbb685369aa5
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned;
+

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "dockerfile": {
     "ignorePaths": [
       "base/Dockerfile.aws",
+      "base/Dockerfile.windows-aws",
       "scripts/",
       "scm/",
       "tools/",


### PR DESCRIPTION
Like we saw with 1809, we're having problems running certain executables on windows-1809.
So, for now, add a windows-aws like aws on the newest base that works for us.