### PR TITLE
Add VS 2022 install

### DIFF
--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -40,5 +40,6 @@ Build-WebKitDockerImage -Image scm -Tag $tag;
 Build-WebKitDockerImage -Image tools -Tag $tag;
 Build-WebKitDockerImage -Image msbuild -Tag $tag;
 Build-WebKitDockerImage -Image msbuild-2017 -Tag $tag;
+Build-WebKitDockerImage -Image msbuild-2022 -Tag $tag;
 Build-WebKitDockerImage -Image buildbot-worker -Tag $tag;
 Build-WebKitDockerImage -Image buildbot -Tag $tag;

--- a/Publish-All.ps1
+++ b/Publish-All.ps1
@@ -30,5 +30,6 @@ Publish-WebKitDockerImage -Image scm -Tag $tag;
 Publish-WebKitDockerImage -Image tools -Tag $tag;
 Publish-WebKitDockerImage -Image msbuild -Tag $tag;
 Publish-WebKitDockerImage -Image msbuild-2017 -Tag $tag;
+Publish-WebKitDockerImage -Image msbuild-2022 -Tag $tag;
 Publish-WebKitDockerImage -Image buildbot-worker -Tag $tag;
 Publish-WebKitDockerImage -Image buildbot -Tag $tag;

--- a/msbuild-2022/Dockerfile
+++ b/msbuild-2022/Dockerfile
@@ -1,0 +1,37 @@
+# escape=`
+
+ARG IMAGE_TAG
+FROM webkitdev/tools:$IMAGE_TAG
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+#--------------------------------------------------------------------
+# Install MS Build Tools 2022
+#--------------------------------------------------------------------
+
+RUN Install-VSBuildTools2022 -InstallationPath C:\MSVS -Workloads `
+    Microsoft.VisualStudio.Component.Roslyn.Compiler, `
+    Microsoft.Component.MSBuild, `
+    Microsoft.VisualStudio.Component.CoreBuildTools, `
+    Microsoft.VisualStudio.Workload.MSBuildTools, `
+    Microsoft.VisualStudio.Component.Windows10SDK, `
+    Microsoft.VisualStudio.Component.VC.CoreBuildTools, `
+    Microsoft.VisualStudio.Component.VC.Tools.x86.x64, `
+    Microsoft.VisualStudio.Component.VC.Redist.14.Latest, `
+    Microsoft.VisualStudio.Component.Windows10SDK.17763, `
+    Microsoft.VisualStudio.Workload.VCTools
+
+#--------------------------------------------------------------------
+# Install LLVM for Clang tooling support
+#--------------------------------------------------------------------
+
+ENV LLVM_VERSION 13.0.0
+
+RUN Register-SystemPath -Path C:\LLVM\bin; `
+    Install-LLVM -Version $env:LLVM_VERSION -InstallationPath C:\LLVM;
+
+#--------------------------------------------------------------------
+# Install Debugging Tools for Windows
+#--------------------------------------------------------------------
+
+RUN Install-Windows10SDK -Features OptionId.WindowsDesktopDebuggers;

--- a/msbuild-2022/manifest.tmpl
+++ b/msbuild-2022/manifest.tmpl
@@ -1,0 +1,38 @@
+image: webkitdev/msbuild-2022:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  -
+    image: webkitdev/msbuild-2022:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1809
+  -
+    image: webkitdev/msbuild-2022:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1903
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1903
+  -
+    image: webkitdev/msbuild-2022:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1909
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1909
+  -
+    image: webkitdev/msbuild-2022:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2004
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2004
+  -
+    image: webkitdev/msbuild-2022:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}20H2
+    platform:
+      architecture: amd64
+      os: windows
+      version: 20H2

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -43,7 +43,7 @@ RUN $scriptArgs = @{ `
 # Install WebKitDev Module
 #--------------------------------------------------------------------
 
-ENV WEBKIT_DEV_VERSION 0.3.0
+ENV WEBKIT_DEV_VERSION 0.4.0
 
 RUN $scriptArgs = @{ `
         Name = 'WebKitDev'; `


### PR DESCRIPTION
Updates the WebKitDev powershell module to 0.4.0 which includes functions in support of Visual Studio 2022. Adds docker images for a new `msbuild-2022` variant.