### PR TITLE
Add git's sh to path to simplify branch cleanup

### DIFF
--- a/buildbot-worker/Dockerfile
+++ b/buildbot-worker/Dockerfile
@@ -23,6 +23,12 @@ RUN Write-Host 'Installing buildbot ...'; `
 COPY BuildbotWorker C:/BW
 
 #--------------------------------------------------------------------
+# Make git sh available in path for branch cleanup
+#--------------------------------------------------------------------
+
+RUN Register-SystemPath -path 'C:\\program files\\git\\bin'
+
+#--------------------------------------------------------------------
 # Entrypoint
 #--------------------------------------------------------------------
 

--- a/buildbot-worker/Dockerfile
+++ b/buildbot-worker/Dockerfile
@@ -26,7 +26,8 @@ COPY BuildbotWorker C:/BW
 # Make git sh available in path for branch cleanup
 #--------------------------------------------------------------------
 
-RUN Register-SystemPath -path 'C:\\program files\\git\\bin'
+RUN Register-SystemPath -path 'C:\program files\git\bin'; `
+    sh --version
 
 #--------------------------------------------------------------------
 # Entrypoint


### PR DESCRIPTION
As part of https://github.com/WebKit/WebKit/pull/198 they're trying to do cleanup for git branches.
Rather than make a script, since this kind of thing keeps happening, make git's sh.exe available for sh -c invocations.

Doing it in the buildbot-worker image rather than scm because it seems specific to the bot environment desires rather than any other general build steps (and might be unwelcome in some non-bot cases). If that were to change we might want to add it to the scm image instead.