### PR TITLE
Add Windows 2022 based images

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -5,11 +5,11 @@ local images = [
   'scripts',
   'scm',
   'tools',
-  'msbuild',
   'msbuild-2017',
+  'msbuild-2019',
   'msbuild-2022',
+  'buildbot-worker',
   'buildbot',
-  'ews',
 ];
 
 local tags = [
@@ -18,6 +18,7 @@ local tags = [
   '1909',
   '2004',
   '20H2',
+  '2022',
   'windows-1809',
   'windows-1903',
   'windows-1909',

--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory)]
-  [ValidateSet('1809','1903','1909','2004','20H2','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws', 'windows-aws')]
+  [ValidateSet('1809','1903','1909','2004','20H2','2022','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws', 'windows-aws')]
   [string]$tag
 )
 

--- a/Publish-All.ps1
+++ b/Publish-All.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory)]
-  [ValidateSet('1809','1903','1909','2004','20H2','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws', 'windows-aws')]
+  [ValidateSet('1809','1903','1909','2004','20H2','2022','windows-1809','windows-1903','windows-1909','windows-2004','windows-20H2','aws', 'windows-aws')]
   [string]$tag
 )
 

--- a/base/Dockerfile.2022
+++ b/base/Dockerfile.2022
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022

--- a/base/manifest.tmpl
+++ b/base/manifest.tmpl
@@ -36,3 +36,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: webkitdev/base:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022

--- a/buildbot-worker/manifest.tmpl
+++ b/buildbot-worker/manifest.tmpl
@@ -36,3 +36,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: webkitdev/buildbot-worker{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022

--- a/buildbot/manifest.tmpl
+++ b/buildbot/manifest.tmpl
@@ -36,3 +36,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: webkitdev/buildbot:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022

--- a/ews-legacy/manifest.tmpl
+++ b/ews-legacy/manifest.tmpl
@@ -36,3 +36,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: webkitdev/ews-legacy:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022

--- a/msbuild-2017/manifest.tmpl
+++ b/msbuild-2017/manifest.tmpl
@@ -36,3 +36,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: webkitdev/msbuild-2017:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022

--- a/msbuild-2019/manifest.tmpl
+++ b/msbuild-2019/manifest.tmpl
@@ -31,8 +31,14 @@ manifests:
       os: windows
       version: 2004
   -
-    image: webkitdev/ews-legacy:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}20H2
+    image: webkitdev/msbuild-2019:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}20H2
     platform:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: webkitdev/msbuild-2019:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022

--- a/msbuild-2022/manifest.tmpl
+++ b/msbuild-2022/manifest.tmpl
@@ -36,3 +36,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: webkitdev/msbuild-2022:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022

--- a/scm/manifest.tmpl
+++ b/scm/manifest.tmpl
@@ -36,3 +36,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: webkitdev/scm:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022

--- a/scripts/manifest.tmpl
+++ b/scripts/manifest.tmpl
@@ -36,3 +36,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: webkitdev/scripts:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: 20H2

--- a/tools/manifest.tmpl
+++ b/tools/manifest.tmpl
@@ -36,3 +36,9 @@ manifests:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: webkitdev/tools:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2022


### PR DESCRIPTION
These work with Windows Server 2022. To build local Windows 10 21H2 is required.