### PR TITLE
Push docker images for builds on default branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,11 @@ stages:
     displayName: Build
     pool:
       vmImage: 'windows-2019'
+    timeoutInMinutes: 120
     steps:
+    #------------------------------------------------
+    # Build images
+    #------------------------------------------------
     - task: Docker@2
       displayName: Build webkitdev/base:1809 image
       inputs:
@@ -53,6 +57,16 @@ stages:
         tags: |
           1809
     - task: Docker@2
+      displayName: Build webkitdev/msbuild-2019:1809 image
+      inputs:
+        command: build
+        repository: webkitdev/msbuild-2019
+        dockerfile: '$(Build.SourcesDirectory)/msbuild-2019/Dockerfile'
+        buildContext: '$(Build.SourcesDirectory)/msbuild-2019'
+        arguments: --build-arg IMAGE_TAG=1809
+        tags: |
+          1809
+    - task: Docker@2
       displayName: Build webkitdev/msbuild-2022:1809 image
       inputs:
         command: build
@@ -80,5 +94,86 @@ stages:
         dockerfile: '$(Build.SourcesDirectory)/buildbot/Dockerfile'
         buildContext: '$(Build.SourcesDirectory)/buildbot'
         arguments: --build-arg IMAGE_TAG=1809
+        tags: |
+          1809
+    #------------------------------------------------
+    # Push images (push to default branch only)
+    #------------------------------------------------
+    - task: Docker@2
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Login to Docker Hub
+      inputs:
+        command: login
+        containerRegistry: DockerHub
+    - task: Docker@2
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Push webkitdev/base:1809 image
+      inputs:
+        command: push
+        containerRegistry: DockerHub
+        repository: webkitdev/base
+        tags: |
+          1809
+    - task: Docker@2
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Push webkitdev/scripts:1809 image
+      inputs:
+        command: push
+        containerRegistry: DockerHub
+        repository: webkitdev/scripts
+        tags: |
+          1809
+    - task: Docker@2
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Push webkitdev/scm:1809 image
+      inputs:
+        command: push
+        containerRegistry: DockerHub
+        repository: webkitdev/scm
+        tags: |
+          1809
+    - task: Docker@2
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Push webkitdev/tools:1809 image
+      inputs:
+        command: push
+        containerRegistry: DockerHub
+        repository: webkitdev/tools
+        tags: |
+          1809
+    - task: Docker@2
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Push webkitdev/msbuild-2019:1809 image
+      inputs:
+        command: push
+        containerRegistry: DockerHub
+        repository: webkitdev/msbuild-2019
+        tags: |
+          1809
+    - task: Docker@2
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Push webkitdev/msbuild-2022:1809 image
+      inputs:
+        command: push
+        containerRegistry: DockerHub
+        repository: webkitdev/msbuild-2022
+        tags: |
+          1809
+    - task: Docker@2
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Push webkitdev/buildbot-worker:1809 image
+      inputs:
+        command: push
+        containerRegistry: DockerHub
+        repository: webkitdev/buildbot-worker
+        tags: |
+          1809
+    - task: Docker@2
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Push webkitdev/buildbot:1809 image
+      inputs:
+        command: push
+        containerRegistry: DockerHub
+        repository: webkitdev/buildbot
         tags: |
           1809


### PR DESCRIPTION
Documentation implies that OSS pipelines can have builds run for 6 hours max. This is more than enough time to build and push the images so use it accordingly.