### PR TITLE
Unset credential.helper in the buildbot image

### DIFF
--- a/buildbot-worker/Dockerfile
+++ b/buildbot-worker/Dockerfile
@@ -34,6 +34,11 @@ RUN Register-SystemPath -path 'C:\program files\git\bin'; `
 #--------------------------------------------------------------------
 RUN git config --system core.autocrlf false
 
+#----------------------------------------------------------------------
+# Unset credential.helper for git due to issues for EWS to apple/WebKit
+#----------------------------------------------------------------------
+RUN git config --system --unset credential.helper
+
 #--------------------------------------------------------------------
 # Entrypoint
 #--------------------------------------------------------------------


### PR DESCRIPTION
When EWS is trying to clone apple/WebKit (rather than webkit/WebKit) the default credential helper tries to get info from terminal and basically locks the build. We've been manually applying the above on EWS machines.