### PR TITLE
Update tools

### DIFF
--- a/msbuild-2019/Dockerfile
+++ b/msbuild-2019/Dockerfile
@@ -29,7 +29,7 @@ RUN Install-VSBuildTools2019 -InstallationPath C:\MSVS -Workloads `
 # Install LLVM for Clang tooling support
 #--------------------------------------------------------------------
 
-ENV LLVM_VERSION 17.0.6
+ENV LLVM_VERSION 18.1.2
 
 RUN Register-SystemPath -Path C:\LLVM\bin; `
     Install-LLVM -Version $env:LLVM_VERSION -InstallationPath C:\LLVM;

--- a/msbuild-2022/Dockerfile
+++ b/msbuild-2022/Dockerfile
@@ -25,7 +25,7 @@ RUN Install-VSBuildTools2022 -InstallationPath C:\MSVS -Workloads `
 # Install LLVM for Clang tooling support
 #--------------------------------------------------------------------
 
-ENV LLVM_VERSION 17.0.6
+ENV LLVM_VERSION 18.1.2
 
 RUN Register-SystemPath -Path C:\LLVM\bin; `
     Install-LLVM -Version $env:LLVM_VERSION -InstallationPath C:\LLVM;

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -108,7 +108,7 @@ RUN gem install webrick -v $env:WEBRICK_VERSION
 # Install CMake
 #--------------------------------------------------------------------
 
-ENV CMAKE_VERSION 3.28.3
+ENV CMAKE_VERSION 3.29.0
 
 RUN Install-CMake -Version $env:CMAKE_VERSION -InstallationPath C:\tools\cmake;
 


### PR DESCRIPTION
cmake -> 3.29.0
llvm -> 18.1.2

A newer version of cmake was required to use llvm 18.1.X. It fixed an issue with incremental builds.