### PR TITLE
Update tools

### DIFF
--- a/buildbot-worker/Dockerfile
+++ b/buildbot-worker/Dockerfile
@@ -6,6 +6,25 @@ FROM webkitdev/msbuild-2022:$IMAGE_TAG
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 #--------------------------------------------------------------------
+# Install vcpkg
+#
+# Remove if Microsoft Visual Studio Build Tools adds in a vcpkg
+# workload. At this time the workload isn't present for Build Tools
+#--------------------------------------------------------------------
+
+ENV VCPKG_VERSION 2024.10.21
+ENV VCPKG_ROOT C:\vcpkg
+
+RUN Install-FromArchive -Name 'vcpkg' -url ('https://github.com/microsoft/vcpkg/archive/refs/tags/{0}.zip' -f $env:VCPKG_VERSION) -archiveRoot ('vcpkg-{0}' -f $env:VCPKG_VERSION) -installationPath $env:VCPKG_ROOT -NoVerify; `
+    & ('{0}/scripts/bootstrap.ps1' -f $env:VCPKG_ROOT) -disableMetrics; `
+    Remove-Item -Recurse -Force (Join-Path $env:VCPKG_ROOT docs); `
+    Remove-Item -Recurse -Force (Join-Path $env:VCPKG_ROOT ports); `
+    Remove-Item -Recurse -Force (Join-Path $env:VCPKG_ROOT toolsrc); `
+    Remove-Item -Recurse -Force (Join-Path $env:VCPKG_ROOT versions); `
+    Register-SystemPath $env:VCPKG_ROOT; `
+    vcpkg version;
+
+#--------------------------------------------------------------------
 # Install buildbot
 #--------------------------------------------------------------------
 

--- a/msbuild-2022/Dockerfile
+++ b/msbuild-2022/Dockerfile
@@ -25,7 +25,7 @@ RUN Install-VSBuildTools2022 -InstallationPath C:\MSVS -Workloads `
 # Install LLVM for Clang tooling support
 #--------------------------------------------------------------------
 
-ENV LLVM_VERSION 19.1.1
+ENV LLVM_VERSION 19.1.3
 
 RUN Register-SystemPath -Path C:\LLVM\bin; `
     Install-LLVM -Version $env:LLVM_VERSION -InstallationPath C:\LLVM;

--- a/scm/Dockerfile
+++ b/scm/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # Install Git for Windows x64 CLI
 #--------------------------------------------------------------------
 
-ENV GIT_VERSION 2.46.2.1
+ENV GIT_VERSION 2.47.0.2
 
 RUN Install-Git -Version $env:GIT_VERSION;
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -57,3 +57,12 @@ RUN $scriptArgs = @{ `
     } `
     `
     Install-Module @scriptArgs;
+
+#--------------------------------------------------------------------
+# Install Chocolatey
+#--------------------------------------------------------------------
+
+RUN Invoke-WebFileRequest -Url https://community.chocolatey.org/install.ps1 -DestinationPath C:install.ps1; `
+    C:\install.ps1; `
+    Remove-Item C:\install.ps1; `
+    choco --version;

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -68,8 +68,8 @@ RUN Install-Perl -Version $env:PERL_VERSION -InstallationPath C:\tools\perl;
 # Install Python 3
 #--------------------------------------------------------------------
 
-ENV PYTHON3_VERSION 3.12.6
-ENV PYTHON3_PIP_VERSION 24.2
+ENV PYTHON3_VERSION 3.12.7
+ENV PYTHON3_PIP_VERSION 24.3.1
 
 RUN Install-Python `
     -Version $env:PYTHON3_VERSION `
@@ -81,7 +81,7 @@ RUN copy-item C:\tools\python3\python.exe C:\tools\python3\python3.exe
 # Install pywin32 for Python 3
 #--------------------------------------------------------------------
 
-ENV PYWIN32_VERSION 306
+ENV PYWIN32_VERSION 308
 
 RUN Write-Host Write-Host 'Installing pywin32 ...'; `
     pip3 install -q ('pywin32=={0}' -f $env:PYWIN32_VERSION); `
@@ -100,7 +100,7 @@ RUN Install-Ruby -Version $env:RUBY_VERSION -InstallationPath C:\tools\ruby;
 # Install webrick gem
 #--------------------------------------------------------------------
 
-ENV WEBRICK_VERSION 1.8.1
+ENV WEBRICK_VERSION 1.9.0
 
 RUN gem install webrick -v $env:WEBRICK_VERSION
 
@@ -108,7 +108,7 @@ RUN gem install webrick -v $env:WEBRICK_VERSION
 # Install CMake
 #--------------------------------------------------------------------
 
-ENV CMAKE_VERSION 3.30.4
+ENV CMAKE_VERSION 3.31.0
 
 RUN Install-CMake -Version $env:CMAKE_VERSION -InstallationPath C:\tools\cmake;
 
@@ -133,11 +133,9 @@ RUN Install-NuGet -Version $env:NUGET_VERSION -InstallationPath C:\tools\nuget;
 #--------------------------------------------------------------------
 
 # Locked version due to later versions not installing in container
-ENV XAMPP_VERSION 7.4.29.1
+ENV XAMPP_VERSION 8.1.6
 
-RUN Install-Xampp -Version $env:XAMPP_VERSION; `
-    Update-XamppPerlLocation -perlPath C:\tools\perl; `
-    Update-XamppPythonLocation -pythonPath C:\tools\python3;
+RUN choco install xampp-81 --confirm --version=$env:XAMPP_VERSION;
 
 #--------------------------------------------------------------------
 # Install Fonts


### PR DESCRIPTION
Adding in `choco` to support a newer `xampp`. Adding in `vcpkg` for buildbots.

git -> 2.47.0.2
python -> 3.12.7
pip -> 24.3.1
pywin32 -> 308
webrick -> 1.9.0
cmake -> 3.31.0
xampp -> 8.1.6
llvm -> 19.1.3
vcpkg -> 2024.10.21