### PR TITLE
Downgrade Git to 2.47.1.2

### DIFF
--- a/scm/Dockerfile
+++ b/scm/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # Install Git for Windows x64 CLI
 #--------------------------------------------------------------------
 
-ENV GIT_VERSION 2.49.0.1
+ENV GIT_VERSION 2.47.1.2
 
 RUN Install-Git -Version $env:GIT_VERSION;
 


### PR DESCRIPTION
We observed random schannel errors with git 4.49.

> fatal: unable to access 'https://github.com/WebKit/WebKit.git/': schannel: server closed abruptly (missing close_notify)

Git for Windows 2.48 and 2.49 has an issue.

git clone - 2.49.0.1 - schannel: failed to receive handshake, SSL/TLS connection failed · Issue #5529 · git-for-windows/git
https://github.com/git-for-windows/git/issues/5529
