### PR TITLE
Add Windows 2025 image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,6 +16,8 @@ jobs:
           os: windows-2022
         - tag: windows-2022
           os: windows-2022
+        - tag: 2025
+          os: windows-2025
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/base/Dockerfile.2025
+++ b/base/Dockerfile.2025
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8.1-windowsservercore-ltsc2025


### PR DESCRIPTION
The Windows 2019 support is going away on GitHub Actions so remove it as well.