### PR TITLE
Remove Windows 2019 builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,8 +16,6 @@ jobs:
           os: windows-2022
         - tag: windows-2022
           os: windows-2022
-        - tag: 1809
-          os: windows-2019
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The `windows-1809` runners are being removed at the end of the month.