### PR TITLE
Add vcpkg workload to build tools installer

### DIFF
--- a/buildbot-worker/Dockerfile
+++ b/buildbot-worker/Dockerfile
@@ -6,25 +6,6 @@ FROM webkitdev/msbuild-2022:$IMAGE_TAG
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 #--------------------------------------------------------------------
-# Install vcpkg
-#
-# Remove if Microsoft Visual Studio Build Tools adds in a vcpkg
-# workload. At this time the workload isn't present for Build Tools
-#--------------------------------------------------------------------
-
-ENV VCPKG_VERSION 2025.04.09
-ENV VCPKG_ROOT C:\vcpkg
-
-RUN Install-FromArchive -Name 'vcpkg' -url ('https://github.com/microsoft/vcpkg/archive/refs/tags/{0}.zip' -f $env:VCPKG_VERSION) -archiveRoot ('vcpkg-{0}' -f $env:VCPKG_VERSION) -installationPath $env:VCPKG_ROOT -NoVerify; `
-    & ('{0}/scripts/bootstrap.ps1' -f $env:VCPKG_ROOT) -disableMetrics; `
-    Remove-Item -Recurse -Force (Join-Path $env:VCPKG_ROOT docs); `
-    Remove-Item -Recurse -Force (Join-Path $env:VCPKG_ROOT ports); `
-    Remove-Item -Recurse -Force (Join-Path $env:VCPKG_ROOT toolsrc); `
-    Remove-Item -Recurse -Force (Join-Path $env:VCPKG_ROOT versions); `
-    Register-SystemPath $env:VCPKG_ROOT; `
-    vcpkg version;
-
-#--------------------------------------------------------------------
 # Install buildbot
 #--------------------------------------------------------------------
 

--- a/msbuild-2022/Dockerfile
+++ b/msbuild-2022/Dockerfile
@@ -13,6 +13,7 @@ RUN Install-VSBuildTools2022 -InstallationPath C:\MSVS -Workloads `
     Microsoft.VisualStudio.Workload.MSBuildTools, `
     Microsoft.VisualStudio.Workload.VCTools, `
     Microsoft.VisualStudio.Component.VC.Tools.x86.x64,`
+    Microsoft.VisualStudio.Component.Vcpkg, `
     Microsoft.VisualStudio.Component.Windows11SDK.26100, `
     Microsoft.VisualStudio.Component.Windows10SDK.18362;
 


### PR DESCRIPTION
Add `Microsoft.VisualStudio.Component.Vcpkg` to the list of workflows and remove the manual installation of `vcpkg`.

Fixes #433.