### PR TITLE
Update to Windows Server 2025

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,9 +16,44 @@ jobs:
           os: windows-2022
         - tag: windows-2022
           os: windows-2022
+        - tag: 2025
+          os: windows-2025
+        - tag: windows-2025
+          os: windows-2025
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
+
+    # Free disk space by removing pre-installed software we don't need
+    - name: Free disk space
+      run: |
+        Write-Host "Disk space before cleanup:"
+        Get-PSDrive C | Select-Object Used, Free | Format-Table
+        $paths = @(
+          'C:\Android',
+          'C:\Program Files\dotnet',
+          'C:\Program Files\MongoDB',
+          'C:\Program Files\PostgreSQL',
+          'C:\Selenium',
+          'C:\hostedtoolcache',
+          'C:\Program Files\Microsoft Visual Studio',
+          'C:\vcpkg',
+          'C:\Miniconda',
+          'C:\Program Files\Go',
+          'C:\Program Files\Node.js',
+          'C:\Program Files\Ruby',
+          'C:\Program Files\Java',
+          'C:\Program Files\Eclipse Adoptium'
+        )
+        foreach ($path in $paths) {
+          if (Test-Path $path) {
+            Write-Host "Removing $path ..."
+            Remove-Item -Recurse -Force $path -ErrorAction SilentlyContinue
+          }
+        }
+        docker system prune -a -f
+        Write-Host "Disk space after cleanup:"
+        Get-PSDrive C | Select-Object Used, Free | Format-Table
 
     # Build Docker images
     - name: Build webkitdev/base
@@ -26,7 +61,7 @@ jobs:
     - name: Build webkitdev/scripts
       run: docker build --tag webkitdev/scripts:${{ matrix.tag }} --build-arg IMAGE_TAG=${{ matrix.tag }} scripts
     - name: Build webkitdev/scm
-      run: docker build --tag webkitdev/scm:${{ matrix.tag }} --build-arg IMAGE_TAG=${{ matrix.tag }} scm      
+      run: docker build --tag webkitdev/scm:${{ matrix.tag }} --build-arg IMAGE_TAG=${{ matrix.tag }} scm
     - name: Build webkitdev/tools
       run: docker build --tag webkitdev/tools:${{ matrix.tag }} --build-arg IMAGE_TAG=${{ matrix.tag }} tools
     - name: Build webkitdev/msbuild-2022
@@ -38,7 +73,7 @@ jobs:
     - name: Verify webkitdev/buildbot-worker
       run: docker run --rm webkitdev/buildbot-worker:${{ matrix.tag }} cmake --system-information
 
-    # Publish Docker images
+    # Publish Docker images to DockerHub
     - name: Dockerhub login
       if: github.ref_name == github.event.repository.default_branch
       uses: docker/login-action@v3

--- a/BUILDBOT.md
+++ b/BUILDBOT.md
@@ -3,7 +3,7 @@ The `docker-webkit-dev` project contains Docker images for running Buildbot
 workers that connect to WebKit infrastructure. The Windows WebKit port builds
 happen within Docker containers running the `webkitdev/buildbot-worker` image.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > To connect to WebKit infrastructure credentials are required.
 > Contact the infrastructure team on [Slack](https://webkit.slack.com) by
 > dropping a message in the `#dev` channel for assistance in connecting new
@@ -18,9 +18,10 @@ compatibility see the
 
 | Tag Name  | Automated | Description |
 |---|:---:|---|
-| 2022 | :white_check_mark: | A Windows 2022 server container |
+| 2022 | :white_check_mark: | A Windows Server 2022 container |
 | windows-2022 | :x: | A Windows container, used for Layout Tests |
-| 1809 | :x: | A Windows 2019 server container |
+| 2025 | :white_check_mark: | A Windows Server 2025 container |
+| windows-2025 | :x: | A Windows container, used for Layout Tests |
 
 Visit [Docker Hub](https://hub.docker.com/r/webkitdev/buildbot-worker/tags) to
 see when the last build happened for the image's tags.
@@ -39,7 +40,7 @@ for more details.
 | BUILD_WORKER_NAME | :white_check_mark: | Name for the worker, provided by infrastructure team  |
 | BUILD_WORKER_PASSWORD | :white_check_mark: | Password for the worker, provided by infrastructure team |
 | BUILD_WORKER_KEEPALIVE | :x: | Time in seconds that messages should be sent by the worker to the server, defaults to 240 |
-| ADMIN_NAME | :x:| Contact name for the admin of the worker | 
+| ADMIN_NAME | :x:| Contact name for the admin of the worker |
 | ADMIN_EMAIL | :x: | Contact e-mail address for the admin of the worker |
 | HOST_DESCRIPTION |:x: | A description of the host running the worker |
 | COMPILER | :white_check_mark: | Needs to be set to `Clang` since the alternative, `cl`, is no longer able to build WebKit |
@@ -60,8 +61,8 @@ COMPILER=Clang
 ```
 
 ## Running the Buildbot worker
-On a Windows Server 2022 machine run the following in a powershell session. On
-Windows Server 2022 the Docker container runs in process isolation mode which
+On a Windows Server 2022/2025 machine run the following in a powershell session.
+On Windows Server 2022/2025 the Docker container runs in process isolation mode which
 gives it access to all the resources of the host.
 
 > [!NOTE]

--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory)]
-  [ValidateSet('1809','2022','aws','windows-1809','windows-aws','windows-2022')]
+  [ValidateSet('2022','windows-2022','2025','windows-2025')]
   [string]$tag
 )
 

--- a/Publish-All.ps1
+++ b/Publish-All.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory)]
-  [ValidateSet('1809','2022','aws','windows-1809','windows-aws','windows-2022')]
+  [ValidateSet('2022','windows-2022','2025','windows-2025')]
   [string]$tag
 )
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Docker images for local WebKit development and CI/CD on Windows.
 
 ## Host Setup
 Using the `webkitdev` Docker images requires a Windows host, ideally Windows 11
-or Windows Server 2022 but Windows 10 and Windows Server 2019 can also be used,
-with [Docker](https://www.docker.com/) installed and targeting Windows
-containers. For new installs follow the latest documentation to setup
+or Windows Server 2022/2025, with [Docker](https://www.docker.com/) installed
+and targeting Windows containers. For new installs follow the latest
+documentation to setup
 [Windows for containers](https://learn.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment).
 
 ## Images
@@ -29,18 +29,16 @@ WebKit infrastructure.
 | [buildbot-worker](https://hub.docker.com/r/webkitdev/buildbot-worker) | Contains Buildbot and scripts to connect to WebKit CI/CD infrastructure |
 
 Docker images support tagging. For Windows images the tag references the version
-of the container base image, Windows Server 2022 and Windows Server 2019.
-Compatibility depends on what the host OS is. In general Windows 11 needs to
-target 2022 tags and Windows 10 needs to target 2019 tags. For the latest
-information on Windows container version compatibility see the
+of the container base image. Compatibility depends on what the host OS is. For
+the latest information on Windows container version compatibility see the
 [documentation](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
 
-| Tag | Automated | Win 11 | Win 10 | Description |
-|---|:---:|:---:|:---:|---|
-| 2022 | :white_check_mark: | :white_check_mark: | :x: | A Windows 2022 server container |
-| windows-2022 | :x: | :white_check_mark: | :x: | A Windows container, used for Layout Tests |
-| 1809 | :x: | :white_check_mark: | :white_check_mark: | A Windows 2019 server container |
-| windows-1809 | :x: | :white_check_mark: | :white_check_mark: | A Windows container, used for Layout Tests |
+| Tag | Automated | Description |
+|---|:---:|---|
+| 2022 | :white_check_mark: | A Windows Server 2022 container |
+| windows-2022 | :x: | A Windows container, used for Layout Tests |
+| 2025 | :white_check_mark: | A Windows Server 2025 container |
+| windows-2025 | :x: | A Windows container, used for Layout Tests |
 
 The `windows-<version>` have a larger base image containing more Windows OS
 components making them ideal for testing WebKit. The other tags use Windows
@@ -48,7 +46,7 @@ Server Core and are suitable for building WebKit.
 
 ### Building locally
 > [!IMPORTANT]
-> Windows 11 and Windows Server 2022 users should pull the images directly from
+> Windows 11 and Windows Server 2022/2025 users should pull the images directly from
 > DockerHub rather than building locally. The only exception is when
 > [updating the images](UPDATING.md).
 
@@ -61,7 +59,7 @@ and tagged. The created time should be within the time frame the script was
 executing in.
 
 ## Building the Windows WebKit port
-With the `webkitdev/msbuild-2022` image everything is there to do a build of 
+With the `webkitdev/msbuild-2022` image everything is there to do a build of
 the Windows WebKit port. Start out by doing a local checkout of the
 [WebKit repository](https://github.com/WebKit/WebKit). The `docker run` command
 needs to be populated with the following fields.
@@ -70,7 +68,7 @@ needs to be populated with the following fields.
 |---|---|
 | tag | The tag to use |
 | cpu-count | The number of CPUs to dedicate to the container (optional on a Windows Server host) |
-| [memory](https://docs.docker.com/reference/cli/docker/container/run/#memory) | The memory limit for the container (optional on a Windows Server host) | 
+| [memory](https://docs.docker.com/reference/cli/docker/container/run/#memory) | The memory limit for the container (optional on a Windows Server host) |
 | [volume](https://docs.docker.com/reference/cli/docker/container/run/#volume) | A local path containing the WebKit checkout, use `/` over `\` |
 
 ```powershell
@@ -88,7 +86,7 @@ like this :point_down:.
 docker run --name build --rm -it `
     --cpu-count=6 --memory=16g `
     --volume C:/GitHub/webkit:C:/webkit `
-    webkitdev/msbuild-2022:2022 powershell
+    webkitdev/msbuild-2022:2025 powershell
 ```
 
 Once the command is run it will place you into a Powershell session. From there
@@ -103,9 +101,9 @@ perl Tools\Scripts\build-webkit
 ```
 
 > [!NOTE]
-> Building in a container in Hyper-V isolation, the default for Windows 11 and
-> 10, will take longer than a local build. Building in a container in process
-> mode, the default for Windows Server 2022 and 2019, will build in a similar
+> Building in a container in Hyper-V isolation, the default for Windows 11,
+> will take longer than a local build. Building in a container in process
+> mode, the default for Windows Server 2022 and 2025, will build in a similar
 > time as a local build.
 >
 > Ideally dedicate a large amount of resources when running in Hyper-V to reduce

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -45,7 +45,7 @@ Use the `Build-All.ps1` PowerShell script to build the images. Again it expects
 a single argument `-Tag` which specifies the tag to build.
 
 ```powershell
-./Build-All -tag 2022
+./Build-All -tag 2025
 ```
 
 Executing the script will create all the `webkitdev` images. Most of `RUN`

--- a/base/Dockerfile.1809
+++ b/base/Dockerfile.1809
@@ -1,1 +1,0 @@
-FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019@sha256:1d05469f3f6d595f05531b4f58157b421526162b26c97a19d98dfd08a5584924

--- a/base/Dockerfile.2025
+++ b/base/Dockerfile.2025
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8.1-windowsservercore-ltsc2025@sha256:fdb22792bfb201f78ba84c54dc76e9f062bb811b9441bfc5c70ec6dd9b5c4c95

--- a/base/Dockerfile.aws
+++ b/base/Dockerfile.aws
@@ -1,1 +1,0 @@
-FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019@sha256:578d07650a3dfe8db5b988f26aa0c23180a248bcb7f5e1ab1d7ba7713b73ad43

--- a/base/Dockerfile.windows-2025
+++ b/base/Dockerfile.windows-2025
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows:1809@sha256:5dc542418c860e622a8da5d2db2dd3f3eb1212c104857ca947dac2fd171a26b5
+FROM mcr.microsoft.com/windows/server:ltsc2025@sha256:bfb0496d2ff297e49b581ea16166ec955d4afbe94a412ad99db52ce554fb327c
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/base/Dockerfile.windows-aws
+++ b/base/Dockerfile.windows-aws
@@ -1,6 +1,0 @@
-FROM mcr.microsoft.com/windows:1809@sha256:bf5f60839adcb5cfd775243bb86069deb88083217c656c456d90fbb685369aa5
-
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
-RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned;
-

--- a/base/manifest.tmpl
+++ b/base/manifest.tmpl
@@ -7,14 +7,14 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/base:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1809
-  -
     image: webkitdev/base:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
     platform:
       architecture: amd64
       os: windows
       version: 2022
+  -
+    image: webkitdev/base:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2025
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2025

--- a/buildbot-worker/manifest.tmpl
+++ b/buildbot-worker/manifest.tmpl
@@ -7,14 +7,14 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/buildbot-worker{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1809
-  -
     image: webkitdev/buildbot-worker{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
     platform:
       architecture: amd64
       os: windows
       version: 2022
+  -
+    image: webkitdev/buildbot-worker{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2025
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2025

--- a/msbuild-2022/manifest.tmpl
+++ b/msbuild-2022/manifest.tmpl
@@ -7,14 +7,14 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/msbuild-2022:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1809
-  -
     image: webkitdev/msbuild-2022:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
     platform:
       architecture: amd64
       os: windows
       version: 2022
+  -
+    image: webkitdev/msbuild-2022:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2025
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2025

--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,6 @@
   "enabledManagers": ["dockerfile"],
   "dockerfile": {
     "ignorePaths": [
-      "base/Dockerfile.aws",
-      "base/Dockerfile.windows-aws",
       "scripts/",
       "scm/",
       "tools/",

--- a/scm/manifest.tmpl
+++ b/scm/manifest.tmpl
@@ -7,14 +7,14 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/scm:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1809
-  -
     image: webkitdev/scm:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
     platform:
       architecture: amd64
       os: windows
       version: 2022
+  -
+    image: webkitdev/scm:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2025
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2025

--- a/scripts/manifest.tmpl
+++ b/scripts/manifest.tmpl
@@ -7,14 +7,14 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/scripts:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1809
-  -
     image: webkitdev/scripts:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
     platform:
       architecture: amd64
       os: windows
-      version: 20H2
+      version: 2022
+  -
+    image: webkitdev/scripts:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2025
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2025

--- a/tools/manifest.tmpl
+++ b/tools/manifest.tmpl
@@ -7,14 +7,14 @@ tags:
 {{/if}}
 manifests:
   -
-    image: webkitdev/tools:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}1809
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1809
-  -
     image: webkitdev/tools:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2022
     platform:
       architecture: amd64
       os: windows
       version: 2022
+  -
+    image: webkitdev/tools:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}2025
+    platform:
+      architecture: amd64
+      os: windows
+      version: 2025


### PR DESCRIPTION
Remove older images (Windows Server 2022, 2019) to simplify maintenance and make it clearer what's supported / automated.

Fixes #454 - the newer SDK doesn't work with Windows Server 2022 under Hyper-V isolation.