### PR TITLE
Update LLVM 21.1.0 -> 21.1.8

### DIFF
--- a/buildbot-worker/BuildbotWorker/Run-BuildbotWorker.ps1
+++ b/buildbot-worker/BuildbotWorker/Run-BuildbotWorker.ps1
@@ -78,12 +78,7 @@ Make sure the amount of disk space is set in the storage-opts setting of the dae
 Write-Host 'Initializing Visual Studio environment';
 Initialize-VSEnvironment -Architecture 'amd64' -Path (Get-VSBuildTools2022VCVarsAllPath);
 
-if ($env:COMPILER -eq 'Clang') {
-  $compilerExe = 'clang-cl.exe';
-} else {
-  $compilerExe = 'cl.exe';
-}
-
+$compilerExe = 'clang-cl.exe';
 $compilerPath = (Get-Command $compilerExe).Path;
 
 Write-Host ('Found compiler at {0}' -f $compilerPath);

--- a/msbuild-2022/Dockerfile
+++ b/msbuild-2022/Dockerfile
@@ -21,7 +21,7 @@ RUN Install-VSBuildTools2022 -InstallationPath C:\MSVS -Workloads `
 # Install LLVM for Clang tooling support
 #--------------------------------------------------------------------
 
-ENV LLVM_VERSION 21.1.0
+ENV LLVM_VERSION 21.1.8
 
 RUN Install-LLVM -Version $env:LLVM_VERSION -InstallationPath C:\LLVM;
 


### PR DESCRIPTION
21.1.0 has issues in StdLibExtras.h switchOn, but it looks like bun is compiling successfully with 21.1.8.