### PR TITLE
Update Windows SDK

### DIFF
--- a/msbuild-2022/Dockerfile
+++ b/msbuild-2022/Dockerfile
@@ -14,8 +14,7 @@ RUN Install-VSBuildTools2022 -InstallationPath C:\MSVS -Workloads `
     Microsoft.VisualStudio.Workload.VCTools, `
     Microsoft.VisualStudio.Component.VC.Tools.x86.x64,`
     Microsoft.VisualStudio.Component.Vcpkg, `
-    Microsoft.VisualStudio.Component.Windows11SDK.26100, `
-    Microsoft.VisualStudio.Component.Windows10SDK.18362;
+    Microsoft.VisualStudio.Component.Windows11SDK.28000;
 
 #--------------------------------------------------------------------
 # Install LLVM for Clang tooling support


### PR DESCRIPTION
Remove Windows 10 SDK. The Skia build now requires Windows 11 SDK for IDWriteFontSet4, WebKit won't build with that SDK.

Update Windows 11 SDK to latest.