### PR TITLE
Install Swift toolchain in tools image

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -25,6 +25,7 @@ site for updates using the :point_down: table.
 | cmake | https://cmake.org/download |
 | ninja | https://ninja-build.org |
 | nuget | https://www.nuget.org/downloads |
+| swift | https://www.swift.org/install/windows |
 | llvm | https://github.com/llvm/llvm-project/releases |
 
 Every software in the Dockerfile has a corresponding `_VERSION` environment

--- a/msbuild-2022/Dockerfile
+++ b/msbuild-2022/Dockerfile
@@ -26,6 +26,17 @@ ENV LLVM_VERSION 21.1.8
 RUN Install-LLVM -Version $env:LLVM_VERSION -InstallationPath C:\LLVM;
 
 #--------------------------------------------------------------------
+# Install Swift toolchain
+#
+# Swift is becoming a required component for building WebKit. It relies
+# on the MSVC toolchain and Windows SDK installed above.
+#--------------------------------------------------------------------
+
+ENV SWIFT_VERSION 6.3.3
+
+RUN Install-Swift -Version $env:SWIFT_VERSION;
+
+#--------------------------------------------------------------------
 # Install Debugging Tools for Windows
 #--------------------------------------------------------------------
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -43,7 +43,7 @@ RUN $scriptArgs = @{ `
 # Install WebKitDev Module
 #--------------------------------------------------------------------
 
-ENV WEBKIT_DEV_VERSION 0.6.4
+ENV WEBKIT_DEV_VERSION 0.7.0
 
 RUN $scriptArgs = @{ `
         Name = 'WebKitDev'; `


### PR DESCRIPTION
Installs Swift 6.3.3 in the `msbuild-2022` image, alongside LLVM and after the Visual Studio Build Tools, using the new `Install-Swift` helper. Compiling with Swift needs the MSVC toolchain and Windows SDK, and the installer integrates with the Visual Studio present in this image. Bumps the WebKitDev module to 0.7.0 and tracks the Swift version in `UPDATING.md`.

Depends on WebKitForWindows/powershell-webkit-dev#47 (the `Install-Swift` helper) — now merged and published as WebKitDev 0.7.0 to the PowerShell Gallery.

Validated end-to-end on Windows: Swift installs silently and `swift`/`swiftc --version` report 6.3.3; a test program compiles and runs, linking with both the MSVC linker and lld (`-use-ld=lld`, via the toolchain's bundled lld-link).